### PR TITLE
feat: cdnsd role enhancements

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: blinklabs
 name: cardano
-version: 0.2.0
+version: 0.2.1
 readme: README.md
 authors:
   - Aurora Gaffney <aurora@blinklabs.io>

--- a/roles/cdnsd/defaults/main.yml
+++ b/roles/cdnsd/defaults/main.yml
@@ -3,7 +3,7 @@
 cdnsd_install_method: 'docker'
 
 # cDNSd version
-cdnsd_version: '0.11.1'
+cdnsd_version: '0.13.0'
 
 # Base host directory for node data
 cardano_node_dir: /opt/cardano
@@ -22,9 +22,16 @@ cdnsd_docker_image: 'ghcr.io/blinklabs-io/cdnsd:{{ cdnsd_version }}'
 # Docker container name
 cdnsd_docker_container_name: cdnsd
 
+# Docker container user
+# This should generally match the owner of the DB dir
+cdnsd_container_user: '{{ cardano_node_user }}'
+
 # Port for host/container
 cdnsd_container_port: 53
 cdnsd_port: 20053
+
+# Extra env vars for cdnsd
+cdnsd_extra_env: {}
 
 # Cardano network
 cdnsd_network: preprod

--- a/roles/cdnsd/tasks/docker.yml
+++ b/roles/cdnsd/tasks/docker.yml
@@ -6,17 +6,22 @@
     - '{{ cdnsd_db_dir }}:{{ cdnsd_db_container_dir }}'
 
 - name: Create container
-  docker_container:
-    name: '{{ cdnsd_docker_container_name }}'
-    image: '{{ cdnsd_docker_image }}'
-    restart_policy: unless-stopped
-    env:
+  vars:
+    cdnsd_base_env:
       DNS_LISTEN_PORT: '{{ cdnsd_container_port | string }}'
       STATE_DIR: '{{ cdnsd_db_container_dir }}'
       INDEXER_SCRIPT_ADDRESS: '{{ cdnsd_indexer_script_address }}'
       INDEXER_INTERCEPT_SLOT: '{{ cdnsd_indexer_intercept_slot | string }}'
       INDEXER_INTERCEPT_HASH: '{{ cdnsd_indexer_intercept_hash }}'
       INDEXER_NETWORK: '{{ cdnsd_network }}'
+    cdnsd_full_env: '{{ cdnsd_base_env | combine(cdnsd_extra_env) }}'
+  docker_container:
+    name: '{{ cdnsd_docker_container_name }}'
+    image: '{{ cdnsd_docker_image }}'
+    user: '{{ cdnsd_container_user }}'
+    restart_policy: unless-stopped
+    env: '{{ cdnsd_full_env }}'
     ports:
-      - '{{ cdnsd_port }}:{{ cdnsd_container_port }}'
+      - '{{ cdnsd_port }}:{{ cdnsd_container_port }}/tcp'
+      - '{{ cdnsd_port }}:{{ cdnsd_container_port }}/udp'
     volumes: '{{ cdnsd_docker_volumes | list }}'


### PR DESCRIPTION
This commit does the following:


* bumps the default cdnsd version
* maps the UDP port in addition to the TCP port
* allows setting the container user, defaulting to data dir owner
* allows providing extra env vars for cdnsd