### PR TITLE
fix: remove unneeded jinja braces around condition

### DIFF
--- a/roles/cardano_node/tasks/docker.yml
+++ b/roles/cardano_node/tasks/docker.yml
@@ -33,7 +33,7 @@
     cardano_node_docker_volumes: '{{ cardano_node_docker_volumes | default([]) + [item] }}'
   loop:
     - '{{ cardano_node_keys_dir }}:{{ cardano_node_keys_container_dir }}'
-  when: '{{ cardano_node_block_producer | bool }}'
+  when: cardano_node_block_producer | bool
 
 - name: Create container
   docker_container:


### PR DESCRIPTION
This fixes a warning from Ansible about conditions having Jinja2 templating delimeters