### PR TITLE
chore: cardano-node 11.0.1

### DIFF
--- a/roles/cardano_node/defaults/main.yml
+++ b/roles/cardano_node/defaults/main.yml
@@ -3,7 +3,7 @@
 cardano_node_install_method: 'docker'
 
 # Cardano node version
-cardano_node_version: '10.5.3'
+cardano_node_version: '11.0.1'
 
 # Cardano network
 cardano_node_network: mainnet


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade default `cardano-node` from 10.5.3 to 11.0.1 in the Ansible role so Docker-based deployments use the latest release.

<sup>Written for commit 8b3b2c69be105b9787a82b9754ffee847f58fab7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded default Cardano Node version to 11.0.1. Deployments using default configurations will now utilize the latest version, with the Docker image tag automatically updated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/ansible-cardano/pull/319)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->